### PR TITLE
Don't clobber CXXFLAGS/CMAKE_CXX_FLAGS

### DIFF
--- a/CMake/CompilerSettingsUnix.cmake
+++ b/CMake/CompilerSettingsUnix.cmake
@@ -6,8 +6,8 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 set(CMAKE_CXX_FLAGS_COMMON "-g -Wall -Wextra -Wno-deprecated -Wno-deprecated-declarations")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_COMMON}")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_COMMON} -O3")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_COMMON}")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_COMMON} -O3")
 
 function(apply_eden_compile_options_to_target THETARGET)
   target_compile_options(${THETARGET}


### PR DESCRIPTION
Summary:
- CMake allows the user to add additional compilation options using
  `CXXFLAGS=<flags>` or `-DCMAKE_CXX_FLAGS=<flags>`.
- Eden clobbers these CMAKE_CXX_FLAGS for both debug and release modes
  which prevents the user from passing additional flags.
- Teach Eden to respect user-supplied compiler flags instead of simply
  overriding them.