### PR TITLE
mononoke: add README.md and the missing pieces for supporting cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /external
 # cmake
 /_build
+
+# Rust libraries and extensions
+Cargo.lock
+target/

--- a/build/fbcode_builder/manifests/mononoke
+++ b/build/fbcode_builder/manifests/mononoke
@@ -1,0 +1,36 @@
+[manifest]
+name = mononoke
+fbsource_path = fbcode/eden
+shipit_project = eden
+shipit_fbcode_builder = true
+
+[git]
+repo_url = https://github.com/facebookexperimental/eden.git
+
+[build.not(os=windows)]
+builder = cargo
+
+[build.os=windows]
+# building Mononoke on windows is not supported
+builder = nop
+
+[cargo]
+build_doc = true
+
+[shipit.pathmap]
+fbcode/eden/oss = .
+fbcode/eden = eden
+fbcode/eden/mononoke/public_autocargo = eden/mononoke
+fbcode/tools/lfs = tools/lfs
+tools/rust/ossconfigs = .
+
+[shipit.strip]
+^fbcode/eden/fs/eden-config\.h$
+^fbcode/eden/hg/.*$
+^fbcode/scm/mononoke/(?!public_autocargo).+/Cargo\.toml$
+
+[dependencies]
+rust-shed
+
+[dependencies.fb=on]
+rust

--- a/eden/mononoke/Cargo.toml
+++ b/eden/mononoke/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+
+members = [
+    "server/session_id",
+    "sshrelay",
+]

--- a/eden/mononoke/README.md
+++ b/eden/mononoke/README.md
@@ -1,0 +1,23 @@
+# Mononoke
+
+Mononoke is a next-generation server for the [Mercurial source control
+system](https://www.mercurial-scm.org/), meant to scale up to accepting
+thousands of commits every hour across millions of files. It is primarily
+written in the [Rust programming language](https://www.rust-lang.org/en-US/).
+
+## Caveat Emptor
+
+Mononoke is still in early stages of development. We are making it available now because we plan to
+start making references to it from our other open source projects.
+
+**The version that we provide on GitHub does not build yet**.
+
+This is because the code is exported verbatim from an internal repository at Facebook, and
+not all of the scaffolding from our internal repository can be easily extracted. The key areas
+where we need to shore things up are:
+
+* Full support for a standard `cargo build`.
+* Open source replacements for Facebook-internal services (blob store, logging etc).
+
+The current goal is to get Mononoke working on Linux. Other Unix-like OSes may
+be supported in the future


### PR DESCRIPTION
Summary:
Take the README.md from
https://github.com/facebookexperimental/mononoke/blob/7ead0e29e41aec0771531a4650b6170bc1ff6566/README.md
and apply it on Eden repo.

Re-add the Cargo.toml file that declares Cargo workspace.

Re-add fbcode_builder/getdeps manifest for Mononoke

Test Plan:
  ./build/fbcode_builder/getdeps.py build mononoke
  ./build/fbcode_builder/getdeps.py test mononoke