### PR TITLE
Github Actions: fix MacOS builds - use old XCode version

### DIFF
--- a/.github/workflows/mononoke.yml
+++ b/.github/workflows/mononoke.yml
@@ -51,6 +51,8 @@ jobs:
       continue-on-error: true
   mac:
     runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
     steps:
     - uses: actions/checkout@v1
     - name: Install Rust Stable


### PR DESCRIPTION
Boost 1.69 doesn't build with XCode >=11.0 according to https://trac.macports.org/ticket/60287 Downgrading XCode to old version seems to fix this (Selecting done as described in https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/)