### PR TITLE
Back out "fix boost macOS build with new Xcode"

### DIFF
--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -81,6 +81,3 @@ builder = boost
 --with-timer
 --with-type_erasure
 --with-wave
-
-[b2.args.os=darwin]
-toolset=clang


### PR DESCRIPTION
Summary:
Original commit changeset: 0b3d22835abb
Original diff: D22417488 (https://github.com/facebookexperimental/eden/commit/ad89d50a79e0145f8713b545c0b3c1a6b0e6ed43)

Reviewed By: markbt

Differential Revision: D22571972

