### PR TITLE
mononoke/x509 identity: add OSS parsing of x509 certificates

### DIFF
--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -75,8 +75,4 @@ jobs:
       run: df -h
     - name: Run Monononke integration tests
       run: |
-        for dir in /tmp/build/installed/python-click-*/lib/fb-py-libs/python-click/click; do
-            export PYTHONPATH="${dir}${PYTHONPATH:+:${PYTHONPATH}}"
-        done
         python3 eden/mononoke/tests/integration/run_tests_getdeps.py /tmp/build/installed /tmp/build/build/mononoke_integration_test
-      continue-on-error: true

--- a/.github/workflows/mononoke-integration_mac.yml
+++ b/.github/workflows/mononoke-integration_mac.yml
@@ -69,12 +69,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install click
+    - name: Install Brew dependencies
+      run: |
+        brew install curl-openssl
     - name: Check space
       run: df -h
     - name: Run Monononke integration tests
       run: |
-        for dir in /tmp/build/installed/python-click-*/lib/fb-py-libs/python-click/click; do
-            export PYTHONPATH="${dir}${PYTHONPATH:+:${PYTHONPATH}}"
-        done
+        export PATH="/usr/local/opt/curl-openssl/bin:$PATH"
         python3 eden/mononoke/tests/integration/run_tests_getdeps.py /tmp/build/installed /tmp/build/build/mononoke_integration_test
-      continue-on-error: true

--- a/eden/mononoke/permission_checker/src/oss.rs
+++ b/eden/mononoke/permission_checker/src/oss.rs
@@ -22,8 +22,23 @@ impl MononokeIdentity {
         bail!("Decoding from JSON is not yet implemented for MononokeIdentity")
     }
 
-    pub fn try_from_x509(_: &X509) -> Result<MononokeIdentitySet> {
-        bail!("Decoding from x509 is not yet implemented for MononokeIdentity")
+    pub fn try_from_x509(cert: &X509) -> Result<MononokeIdentitySet> {
+        let subject_vec: Result<Vec<_>> = cert
+            .subject_name()
+            .entries()
+            .map(|entry| {
+                Ok(format!(
+                    "{}={}",
+                    entry.object().nid().short_name()?,
+                    entry.data().as_utf8()?
+                ))
+            })
+            .collect();
+        let subject_name = subject_vec?.as_slice().join(",");
+
+        let mut idents = MononokeIdentitySet::new();
+        idents.insert(MononokeIdentity::new("X509_SUBJECT_NAME", subject_name)?);
+        Ok(idents)
     }
 }
 

--- a/eden/mononoke/tests/integration/library.sh
+++ b/eden/mononoke/tests/integration/library.sh
@@ -6,6 +6,14 @@
 
 # Library routines and initial setup for Mononoke-related tests.
 
+if [ -f "$TEST_FIXTURES/facebook/fb_library.sh" ]; then
+  # shellcheck source=fbcode/eden/mononoke/tests/integration/facebook/fb_library.sh
+  . "$TEST_FIXTURES/facebook/fb_library.sh"
+fi
+
+ALLOWED_IDENTITY_TYPE="${FB_ALLOWED_IDENTITY_TYPE:-X509_SUBJECT_NAME}"
+ALLOWED_IDENTITY_DATA="${FB_ALLOWED_IDENTITY_DATA:-CN=localhost,O=Mononoke,C=US,ST=CA}"
+
 if [[ -n "$DB_SHARD_NAME" ]]; then
   MONONOKE_DEFAULT_START_TIMEOUT=60
 else
@@ -479,15 +487,13 @@ EOF
 
   echo "{}" > "$TESTTMP/mononoke_tunables.json"
 
-  ALLOWED_USERNAME="${ALLOWED_USERNAME:-myusername0}"
-
   cd mononoke-config || exit 1
   mkdir -p common
   touch common/commitsyncmap.toml
   cat > common/common.toml <<CONFIG
 [[whitelist_entry]]
-identity_type = "USER"
-identity_data = "$ALLOWED_USERNAME"
+identity_type = "$ALLOWED_IDENTITY_TYPE"
+identity_data = "$ALLOWED_IDENTITY_DATA"
 CONFIG
 
   echo "# Start new config" > common/storage.toml

--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -53,12 +53,14 @@ eden_scm_packages = join(install_dir, "eden_scm/lib/python2.7/site-packages")
 pythonpath = env.get("PYTHONPATH")
 env["PYTHONPATH"] = eden_scm_packages + (":{}".format(pythonpath) if pythonpath else "")
 
-subprocess.run(
-    [
-        sys.executable,
-        join(repo_root, "eden/mononoke/tests/integration/integration_runner_real.py"),
-        join(build_dir, "manifest.json"),
-    ]
-    + tests,
-    env=env,
+sys.exit(
+    subprocess.run(
+        [
+            sys.executable,
+            join(repo_root, "eden/mononoke/tests/integration/integration_runner_real.py"),
+            join(build_dir, "manifest.json"),
+        ]
+        + tests,
+        env=env,
+    ).returncode,
 )


### PR DESCRIPTION
Summary: This parsing uses the standard "subject name" field of a x509 certificate to create MononokeIdentity.

Differential Revision: D22627150

