### PR TITLE
revisionstore: fix GitHub build

### DIFF
--- a/eden/scm/lib/revisionstore/src/lfs.rs
+++ b/eden/scm/lib/revisionstore/src/lfs.rs
@@ -1536,7 +1536,7 @@ impl LocalStore for LfsFallbackRemoteStore {
 mod tests {
     use super::*;
 
-    use std::{env::set_var, str::FromStr};
+    use std::str::FromStr;
 
     use quickcheck::quickcheck;
     use tempfile::TempDir;
@@ -2088,6 +2088,7 @@ mod tests {
     #[cfg(feature = "fb")]
     mod fb_test {
         use super::*;
+        use std::env::set_var;
 
         #[test]
         fn test_lfs_non_present() -> Result<()> {
@@ -2436,7 +2437,7 @@ mod tests {
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
-        remote.batch_upload(&objs, { move |sha256| local_lfs.blobs.get(&sha256) })?;
+        remote.batch_upload(&objs, move |sha256| local_lfs.blobs.get(&sha256))?;
 
         assert_eq!(remote_lfs_file_store.get(&blob1.0)?, Some(blob1.2));
         assert_eq!(remote_lfs_file_store.get(&blob2.0)?, Some(blob2.2));

--- a/eden/scm/lib/revisionstore/types/lib.rs
+++ b/eden/scm/lib/revisionstore/types/lib.rs
@@ -5,8 +5,6 @@
  * GNU General Public License version 2.
  */
 
-#![deny(warnings)]
-
 //! revisionstore_types - Data types used by the revisionstore crate
 
 mod datastore;


### PR DESCRIPTION
Summary:
See https://github.com/facebookexperimental/eden/runs/1034006668:

  note: the lint level is defined here
      --> src/lib.rs:125:9
       |
  125  | #![deny(warnings)]
       |         ^^^^^^^^
       = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`

  error: unnecessary braces around method argument
      --> src/lfs.rs:2439:36
       |
  2439 |         remote.batch_upload(&objs, { move |sha256| local_lfs.blobs.get(&sha256) })?;
       |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these braces
       |
  note: the lint level is defined here
      --> src/lib.rs:125:9
       |
  125  | #![deny(warnings)]
       |         ^^^^^^^^
       = note: `#[deny(unused_braces)]` implied by `#[deny(warnings)]`

  error: aborting due to 2 previous errors

  error: could not compile `revisionstore`.

I dropped `#![deny(warnings)]` as I don't think warnings like the above ones
should break the build.

Reviewed By: singhsrb

Differential Revision: D23362178

