### PR TITLE
mononoke/integration tests: fix up integration tests using hooks

### DIFF
--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -86,7 +86,6 @@ else:
         "test-gitimport-octopus.t",  # Unknown, fails on GitHub MacOs
         "test-gitimport.t",  # Issue with hggit extension
         "test-hook-tailer.t",  # Issue with hggit extension
-        "test-hooks.t",  # Hooks are not in OSS yet
         "test-infinitepush-lfs.t",  # Timed out
         "test-large-path-and-content.t",  # Complex bash issues
         "test-lfs-copytracing.t",  # Timed out
@@ -109,9 +108,7 @@ else:
         "test-mononoke-hg-sync-job-generate-bundles-lfs-verification.t",  # Timed out
         "test-mononoke-hg-sync-job-generate-bundles-lfs.t",  # Timed out
         "test-push-protocol-lfs.t",  # Timed out
-        "test-push-redirector-pushrebase-hooks.t",  # Hooks are not in OSS yet
         "test-pushrebase-block-casefolding.t",  # Most likely MacOS path case insensitivity
-        "test-pushrebase-discovery.t",  # Hooks are not in OSS yet
         "test-remotefilelog-lfs.t",  # Timed out
         "test-scs-blame.t",  # Missing SCS_SERVER
         "test-scs-common-base.t",  # Missing SCS_SERVER

--- a/eden/mononoke/tests/integration/test-push-redirector-force-pushrebase-hooks.t
+++ b/eden/mononoke/tests/integration/test-push-redirector-force-pushrebase-hooks.t
@@ -31,6 +31,10 @@
   > hook_name="deny_files"
   > [[hooks]]
   > name="deny_files"
+  > [hooks.config_string_lists]
+  >   deny_patterns = [
+  >     "/[.]git/",
+  >   ]
   > CONFIG
 
   $ cat > $TESTTMP/mononoke_tunables.json <<EOF

--- a/eden/mononoke/tests/integration/test-push-redirector-pushrebase-hooks.t
+++ b/eden/mononoke/tests/integration/test-push-redirector-pushrebase-hooks.t
@@ -31,6 +31,10 @@
   > hook_name="deny_files"
   > [[hooks]]
   > name="deny_files"
+  > [hooks.config_string_lists]
+  >   deny_patterns = [
+  >     "/[.]git/",
+  >   ]
   > CONFIG
   $ start_large_small_repo --local-configerator-path="$TESTTMP/configerator"
   Starting Mononoke server


### PR DESCRIPTION
Hooks have been recently made public. Remove from list of excluded tests the ones that were blocked by missing hooks and fix them up.