### PR TITLE
mononoke/integration tests: handle case-sensitive related tests

### DIFF
--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -12,6 +12,7 @@ import sys
 from glob import iglob
 from os.path import abspath, basename, dirname, join
 from pathlib import Path
+from sys import platform
 
 
 parser = argparse.ArgumentParser(
@@ -73,7 +74,6 @@ else:
     excluded_tests = {
         "test-backsync-forever.t",  # Unknown issue
         "test-blobimport-lfs.t",  # Timed out
-        "test-blobimport.t",  # Case insensitivity of paths in MacOS
         "test-bookmarks-filler.t",  # Probably missing binary
         "test-cmd-manual-scrub.t",  # Just wrong outout
         "test-edenapi-server-commit-location-to-hash.t",  # Missing eden/scm's commands
@@ -108,7 +108,6 @@ else:
         "test-mononoke-hg-sync-job-generate-bundles-lfs-verification.t",  # Timed out
         "test-mononoke-hg-sync-job-generate-bundles-lfs.t",  # Timed out
         "test-push-protocol-lfs.t",  # Timed out
-        "test-pushrebase-block-casefolding.t",  # Most likely MacOS path case insensitivity
         "test-remotefilelog-lfs.t",  # Timed out
         "test-scs-blame.t",  # Missing SCS_SERVER
         "test-scs-common-base.t",  # Missing SCS_SERVER
@@ -123,6 +122,11 @@ else:
         "test-traffic-replay.t",  # Missing TRAFFIC_REPLAY
         "test-unbundle-replay-hg-recording.t",  # Returns different data in OSS
     }
+
+    if platform == "darwin":
+        excluded_tests.update(
+            {"test-pushrebase-block-casefolding.t"}  # MacOS is path case insensitive
+        )
 
     tests = [
         t

--- a/eden/mononoke/tests/integration/test-blobimport.t
+++ b/eden/mononoke/tests/integration/test-blobimport.t
@@ -37,8 +37,8 @@
 
 # Capitals and underscores in a filename. Total len of the filename is 253
 # 253 because: 253 + len(".i") = 255 (max filename in UNIX system)
-  $ UNDERSCORES=`printf '_%.0s' {1..123}`
-  $ CAPITALS=`printf 'A%.0s' {1..130}`
+  $ UNDERSCORES=`printf '_%.0s' {1..122}`
+  $ CAPITALS=`printf 'A%.0s' {1..131}`
   $ echo s > "$UNDERSCORES$CAPITALS"
   $ hg commit -Aqm "underscores, capitals"
 


### PR DESCRIPTION
The test-blobimport.t creates few files that are conflicting in a case insensitive file system, so make them differ by adding an extra prefix.

test-pushrebase-block-casefolding.t is directly testing a feature of case sensitive file system, so it cannot be really tested on MacOS