### PR TITLE
mononoke/integration tests: deal with bash issues on tests

### DIFF
--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -29,6 +29,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '2.7'
+    - name: Install Apt-get dependencies
+      run: |
+        sudo apt-get install nmap
     - name: Install system deps
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive eden_scm
     - name: Build eden_scm dependencies

--- a/.github/workflows/mononoke-integration_mac.yml
+++ b/.github/workflows/mononoke-integration_mac.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: '2.7'
     - name: Install Brew dependencies
       run: |
-        brew install bash coreutils curl-openssl gnu-sed grep jq
+        brew install bash coreutils curl-openssl gnu-sed grep jq nmap
     - name: Install system deps
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive eden_scm
     - name: Build eden_scm dependencies

--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -87,7 +87,7 @@ else:
         "test-gitimport.t",  # Issue with hggit extension
         "test-hook-tailer.t",  # Issue with hggit extension
         "test-infinitepush-lfs.t",  # Timed out
-        "test-large-path-and-content.t",  # Complex bash issues
+        "test-large-path-and-content.t",  # Timed out
         "test-lfs-copytracing.t",  # Timed out
         "test-lfs-server-acl-check.t",  # Timed out
         "test-lfs-server-consistent-hashing.t",  # Timed out
@@ -96,7 +96,6 @@ else:
         "test-lfs-server-identity-parsing-untrusted.t",  # Timed out
         "test-lfs-server-identity-parsing.t",  # Timed out
         "test-lfs-server-max-upload-size.t",  # Timed out
-        "test-lfs-server-proxy-skip-upstream.t",  # Complex bash issues
         "test-lfs-server-proxy-sync.t",  # Timed out
         "test-lfs-server-proxy.t",  # Timed out
         "test-lfs-server-rate-limiting.t",  # Timed out

--- a/eden/mononoke/tests/integration/test-lfs-server-proxy-skip-upstream.t
+++ b/eden/mononoke/tests/integration/test-lfs-server-proxy-skip-upstream.t
@@ -13,7 +13,7 @@
 # Start a "server" that never responds as the upstream
   $ upstream_port="$(get_free_socket)"
   $ upstream="http://127.0.0.1:${upstream_port}/"
-  $ nc --sh-exec "sleep 1" --keep-open --listen 127.0.0.1 "$upstream_port" &
+  $ ncat --sh-exec "sleep 1" --keep-open --listen 127.0.0.1 "$upstream_port" &
   $ nc_pid="$!"
 
 # Start a LFS server


### PR DESCRIPTION
One test was fixed earlier by switching MacOS to use modern version of bash, the other is fixed here by installing "nmap" and using "ncat" from within it on both linux and mac.