### PR TITLE
mononoke/integration CI: try to free up some space before running tests

### DIFF
--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Check space
+    - name: Check space before cleanup
       run: df -h
     - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
-      run: sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    - name: Check space
-      run: df -h
+      run: |
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
@@ -50,6 +52,12 @@ jobs:
         --no-deps
         --src-dir=.
         eden_scm
+    - name: Check space before cleanup
+      run: df -h
+    - name: Clean up eden_scm build
+      run: |
+        rm -rf /tmp/build/build/eden_scm/*
+        df -h
     - name: Build mononoke dependencies
       run: >-
         python3 build/fbcode_builder/getdeps.py build
@@ -66,6 +74,12 @@ jobs:
         --no-deps
         --src-dir=.
         mononoke
+    - name: Check space before cleanup
+      run: df -h
+    - name: Clean up mononoke build
+      run: |
+        rm -rf /tmp/build/build/mononoke/*
+        df -h
     - name: Install Python 3.7
       uses: actions/setup-python@v2
       with:
@@ -74,12 +88,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install click
-    - name: Check space
+    - name: Check space before running tests
       run: df -h
     - name: Run Monononke integration tests
       run: |
         python3 eden/mononoke/tests/integration/run_tests_getdeps.py /tmp/build/installed /tmp/build/build/mononoke_integration_test
       continue-on-error: true
+    - name: Check space after running tests
+      run: df -h
     - name: Rerun failed Monononke integration tests (reduce flakiness)
       run: |
         cat eden/mononoke/tests/integration/.test* || true

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Check space
+    - name: Check space before cleanup
       run: df -h
     - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
-      run: sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    - name: Check space
-      run: df -h
+      run: |
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
@@ -31,11 +33,11 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --allow-system-packages --only-deps --src-dir=. mononoke
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py build --allow-system-packages --no-deps --src-dir=. mononoke
-    - name: Check space
+    - name: Check space after build
       run: df -h
     - name: Test mononoke
       run: python3 build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. mononoke
-    - name: Check space
+    - name: Check space after running tests
       run: df -h
     - name: Install Rust Beta
       uses: actions-rs/toolchain@v1
@@ -55,5 +57,5 @@ jobs:
     - name: Test mononoke with nightly toolchain
       run: python3 build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. mononoke
       continue-on-error: true
-    - name: Check space
+    - name: Check space at the end
       run: df -h

--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -9,12 +9,12 @@ libzstd
 libzstd-dev
 
 [download]
-url = https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz
-sha256 = 59ef70ebb757ffe74a7b3fe9c305e2ba3350021a918d168a046c6300aeea9315
+url = https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz
+sha256 = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
 
 [build]
 builder = cmake
-subdir = zstd-1.4.4/build/cmake
+subdir = zstd-1.4.5/build/cmake
 
 # The zstd cmake build explicitly sets the install name
 # for the shared library in such a way that cmake discards

--- a/eden/mononoke/server/context/src/oss.rs
+++ b/eden/mononoke/server/context/src/oss.rs
@@ -7,15 +7,15 @@
 
 use anyhow::Error;
 use futures::{future::ok, Future};
-use sshrelay::SshEnvVars;
+use sshrelay::Metadata;
 
 use crate::core::CoreContext;
 
-pub fn is_quicksand(_ssh_env_vars: &SshEnvVars) -> bool {
+pub fn is_quicksand(_ssh_env_vars: &Metadata) -> bool {
     false
 }
 
-pub fn is_external_sync(_ssh_env_vars: &SshEnvVars) -> bool {
+pub fn is_external_sync(_ssh_env_vars: &Metadata) -> bool {
     false
 }
 

--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -169,7 +169,9 @@ def get_test_groups(repo_root):
 def get_tests_to_run(repo_root, tests, groups_to_run, rerun_failed):
     test_groups = get_test_groups(repo_root)
 
-    groups_to_run = set(groups_to_run or ([TestGroup.PASSING] if not tests else []))
+    groups_to_run = set(
+        groups_to_run or ([TestGroup.PASSING] if not (tests or rerun_failed) else [])
+    )
 
     tests_to_run = set()
     for group in groups_to_run:

--- a/eden/mononoke/tests/integration/test-metadata.t
+++ b/eden/mononoke/tests/integration/test-metadata.t
@@ -57,29 +57,4 @@ pull from mononoke and log data
   remote: }
   searching for changes
   no changes found
-  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true LOCALIP="2401:db00:31ff:ff1f:face:b00c:0:598" hgmn pull
-  pulling from ssh://user@dummy/repo
-  remote: Metadata {
-  remote:     session_id: SessionId(
-  remote:         "*", (glob)
-  remote:     ),
-  remote:     identities: {
-  remote:         MononokeIdentity {
-  remote:             id_type: "USER",
-  remote:             id_data: "foobar",
-  remote:         },
-  remote:     },
-  remote:     priority: Default,
-  remote:     client_debug: true,
-  remote:     client_ip: Some(
-  remote:         V6(
-  remote:             2401:db00:31ff:ff1f:face:b00c:0:598,
-  remote:         ),
-  remote:     ),
-  remote:     client_hostname: Some(
-  remote:         "hg-regional6-shv-01.rcln0.facebook.com",
-  remote:     ),
-  remote: }
-  searching for changes
-  no changes found
 


### PR DESCRIPTION
We are running out of space on integration tests runs on Linux. In order to avoid that this change is adding some cleanups.

1. Adding `docker rmi $(docker image ls -aq)` frees up 4 GB.
2. Cleaning up `eden_scm` build directory frees up 3 GB.
3. Cleaning up `mononoke` build directory frees up 1 GB.