### PR TITLE
mononoke/commitcloud_bookmarks_filler: make it public

### DIFF
--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Check space
+    - name: Check space before cleanup
       run: df -h
     - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
-      run: sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      run: |
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Check space
       run: df -h
     - name: Install Rust Stable
@@ -50,6 +54,12 @@ jobs:
         --no-deps
         --src-dir=.
         eden_scm
+    - name: Check space before cleanup
+      run: df -h
+    - name: Clean up eden_scm build
+      run: |
+        rm -rf /tmp/build/build/eden_scm/*
+        df -h
     - name: Build mononoke dependencies
       run: >-
         python3 build/fbcode_builder/getdeps.py build
@@ -66,6 +76,12 @@ jobs:
         --no-deps
         --src-dir=.
         mononoke
+    - name: Check space before cleanup
+      run: df -h
+    - name: Clean up mononoke build
+      run: |
+        rm -rf /tmp/build/build/mononoke/*
+        df -h
     - name: Install Python 3.7
       uses: actions/setup-python@v2
       with:
@@ -74,12 +90,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install click
-    - name: Check space
+    - name: Check space before running tests
       run: df -h
     - name: Run Monononke integration tests
       run: |
         python3 eden/mononoke/tests/integration/run_tests_getdeps.py /tmp/build/installed /tmp/build/build/mononoke_integration_test
       continue-on-error: true
+    - name: Check space after running tests
+      run: df -h
     - name: Rerun failed Monononke integration tests (reduce flakiness)
       run: |
         cat eden/mononoke/tests/integration/.test* || true

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Check space
+    - name: Check space before cleanup
       run: df -h
     - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
-      run: sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      run: |
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Check space
       run: df -h
     - name: Install Rust Stable
@@ -31,11 +35,11 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --allow-system-packages --only-deps --src-dir=. mononoke
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py build --allow-system-packages --no-deps --src-dir=. mononoke
-    - name: Check space
+    - name: Check space after build
       run: df -h
     - name: Test mononoke
       run: python3 build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. mononoke
-    - name: Check space
+    - name: Check space after running tests
       run: df -h
     - name: Install Rust Beta
       uses: actions-rs/toolchain@v1
@@ -55,5 +59,5 @@ jobs:
     - name: Test mononoke with nightly toolchain
       run: python3 build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. mononoke
       continue-on-error: true
-    - name: Check space
+    - name: Check space at the end
       run: df -h

--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -9,12 +9,12 @@ libzstd
 libzstd-dev
 
 [download]
-url = https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz
-sha256 = 59ef70ebb757ffe74a7b3fe9c305e2ba3350021a918d168a046c6300aeea9315
+url = https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz
+sha256 = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
 
 [build]
 builder = cmake
-subdir = zstd-1.4.4/build/cmake
+subdir = zstd-1.4.5/build/cmake
 
 # The zstd cmake build explicitly sets the install name
 # for the shared library in such a way that cmake discards

--- a/eden/mononoke/Cargo.toml
+++ b/eden/mononoke/Cargo.toml
@@ -310,6 +310,7 @@ members = [
     "microwave/builder",
     "microwave/if",
     "mononoke_api",
+    "mononoke_commitcloud_bookmarks_filler",
     "mononoke_hg_sync_job",
     "mononoke_types",
     "mononoke_types/if",

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/Cargo.toml
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "mononoke_commitcloud_bookmarks_filler"
+edition = "2018"
+version = "0.1.0"
+authors = ['Facebook']
+license = "GPLv2+"
+include = ["schemas/**/*.sql", "src/**/*.rs"]
+
+[dependencies]
+blobrepo = { path = "../blobrepo" }
+blobrepo_hg = { path = "../blobrepo/blobrepo_hg" }
+bookmarks = { path = "../bookmarks" }
+cmdlib = { path = "../cmdlib" }
+context = { path = "../server/context" }
+mercurial_types = { path = "../mercurial/types" }
+metaconfig_types = { path = "../metaconfig/types" }
+scuba_ext = { path = "../common/scuba_ext" }
+sql_construct = { path = "../common/sql_construct" }
+sql_ext = { path = "../common/rust/sql_ext" }
+cloned = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
+fbinit = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
+futures_ext = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
+sql = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
+stats = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
+anyhow = "1.0"
+ascii = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+clap = "2.33"
+futures = { version = "0.3.5", features = ["async-await", "compat"] }
+futures-old = { package = "futures", version = "0.1" }
+slog = { version = "2.5", features = ["max_level_debug"] }
+thiserror = "1.0"
+tokio = { version = "=0.2.13", features = ["full"] }
+
+[dev-dependencies]
+mercurial_types-mocks = { path = "../mercurial/types/mocks" }
+maplit = "1.0"
+tokio-compat = "0.1"

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/README.md
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/README.md
@@ -1,0 +1,39 @@
+# Commit Cloud Scratch Bookmarks Sync
+
+This process syncs scratch bookmarks from Mercurial into Mononoke. This works by
+operating over a queue of changes that is kept up to date by Mercurial with new
+entries whenever a scratch bookmark move happens (the `replaybookmarksqueue`
+table in `xdb.infinitepush`).
+
+The way the sync works is by pulling entries from the queue, consolidating them
+by bookmarks, then attempting to update individual bookmarks. Since the entries
+in the queue reference HG Changeset IDs (they were created in Mercurial), this
+requires checking for a corresponding Bonsai Changeset first.
+
+## Known Limitations
+
+If too many bookmarks are repeatedly failing to sync (because their commits are
+missing, forever), the process might stop making progress as it repeatedly
+retries to apply those changes. Specifically, "too many" means "more than the
+queue query limit".
+
+This is probably acceptable for now, considering:
+
+- There isn't that much volume on scratch bookmarks.
+- The queue query limit is reasonably high compared to the expected volume of
+  scratch bookmarks.
+
+In addition, it's worth noting that if a bookmark is being updated concurrently
+in two transactions in Mercurial, we might get an inconsistent ordering between
+the replay queue and the state of bookmarks in Mercurial (similarly to what we
+had happen in the Mononoke -> Mercurial sync job). For now, we're accepting this
+risk, considering:
+
+- Scratch bookmarks aren't getting that much traffic that this is likely to be a
+  problem.
+- Those two transactions would have to update the Bookmarks table in MySQL, and
+  I believe MySQL will actually lock one transaction until the other completes
+  in this case (compared to e.g. PostgreSQL, which will allow both to proceed
+  then raise a serialization error later).
+- Fixing this would require a substantial and risky rework of Mercurial's
+  scratch bookmarks handling, which we're deprecating.

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/schemas/sqlite-replaybookmarksqueue.sql
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/schemas/sqlite-replaybookmarksqueue.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+CREATE TABLE `replaybookmarksqueue` (
+  `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  /* NOTE: this lives in a Mercurial DB, so we have repo names, not IDs there */
+  `reponame` VARBINARY NOT NULL,
+  `bookmark` VARBINARY NOT NULL,
+  `node` VARBINARY NOT NULL,
+  `bookmark_hash` VARBINARY NOT NULL,
+  `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `synced` INT NOT NULL DEFAULT 0,
+  `backfill` INT NOT NULL DEFAULT 0
+);

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/errors.rs
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/errors.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+use anyhow::Error;
+use bookmarks::BookmarkName;
+use mercurial_types::HgChangesetId;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ErrorKind {
+    #[error("Bookmark transaction failed")]
+    BookmarkTransactionFailed,
+
+    #[error("Bookmark does not match scratch namespace: {0:?}")]
+    InvalidBookmarkForNamespace(BookmarkName),
+
+    #[error("HG Changeset does not exist: {0:?}")]
+    HgChangesetDoesNotExist(HgChangesetId),
+
+    #[error("An error ocurred interacting with the blob repo")]
+    BlobRepoError(#[source] Error),
+}

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/main.rs
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/main.rs
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+#![feature(never_type)]
+#![deny(warnings)]
+
+use anyhow::{format_err, Error, Result};
+use bookmarks::BookmarkName;
+use clap::{Arg, ArgMatches};
+use cloned::cloned;
+use cmdlib::{args, helpers::block_execute};
+use fbinit::FacebookInit;
+use futures::{
+    compat::{Future01CompatExt, Stream01CompatExt},
+    future,
+    stream::StreamExt,
+};
+use futures_ext::StreamExt as StreamExt2;
+use futures_old::stream::Stream;
+use mercurial_types::HgChangesetId;
+use metaconfig_types::RepoConfig;
+use scuba_ext::ScubaSampleBuilder;
+use sql_construct::{facebook::FbSqlConstruct, SqlConstruct};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::delay_for;
+
+mod errors;
+mod replay_stream;
+mod sql_replay_bookmarks_queue;
+mod sync_bookmark;
+
+use replay_stream::BufferSize;
+use sql_replay_bookmarks_queue::{Backfill, QueueLimit, SqlReplayBookmarksQueue};
+
+const DEFAULT_BUFFER_SIZE: usize = 50;
+const DEFAULT_QUEUE_LIMIT: usize = 5000;
+
+const ARG_BUFFER_SIZE: &'static str = "buffer-size";
+const ARG_MAX_ITERATIONS: &'static str = "max-iterations";
+const ARG_CTX_SCUBA_TABLE: &'static str = "log-scuba-table";
+const ARG_STATUS_SCUBA_TABLE: &'static str = "status-scuba-table";
+const ARG_QUEUE_LIMIT: &'static str = "queue-limit";
+const ARG_SQL_QUEUE_SOURCE: &'static str = "sql-queue-type";
+const ARG_SQL_QUEUE_NAME: &'static str = "sql-name";
+const ARG_DELAY: &'static str = "delay";
+const ARG_BACKFILL: &'static str = "backfill";
+
+const SOURCE_SQLITE: &'static str = "sqlite";
+const SOURCE_XDB: &'static str = "xdb";
+
+// NOTE: We have to use our own implementation of open_sql here (as opposed to the ones used in the
+// rest of Mononoke), because we're getting our XDB tier from args, not from the Mononoke config.
+// The reason for that is the XDB DB for the queue lives in a Mercurial XDB, not in the Mononoke
+// XBD.
+async fn open_sql(
+    fb: FacebookInit,
+    matches: &ArgMatches<'_>,
+    readonly_storage: bool,
+) -> Result<SqlReplayBookmarksQueue, Error> {
+    let mysql_options = args::parse_mysql_options(matches);
+
+    // NOTE: We make this required in our args, hence unwrap.
+    let name = matches.value_of(ARG_SQL_QUEUE_NAME).unwrap();
+
+    match matches.value_of(ARG_SQL_QUEUE_SOURCE) {
+        Some(SOURCE_SQLITE) => {
+            let mut path = PathBuf::new();
+            path.push(name);
+            SqlReplayBookmarksQueue::with_sqlite_path(
+                path.join(SqlReplayBookmarksQueue::LABEL),
+                readonly_storage,
+            )
+        }
+        Some(SOURCE_XDB) => {
+            SqlReplayBookmarksQueue::with_xdb(fb, name.to_string(), mysql_options, readonly_storage)
+                .await
+        }
+        // NOTE: We make this required and restrict valid values in our args, hence the panic.
+        x => panic!("Invalid {}: {:?}", ARG_SQL_QUEUE_SOURCE, x),
+    }
+}
+
+#[fbinit::main]
+fn main(fb: FacebookInit) -> Result<()> {
+    let app = args::MononokeApp::new("Replay bookmarks from Mercurial into Mononoke")
+        .with_advanced_args_hidden()
+        .with_fb303_args()
+        .build()
+        .arg(
+            Arg::with_name(ARG_CTX_SCUBA_TABLE)
+                .long(ARG_CTX_SCUBA_TABLE)
+                .takes_value(true)
+                .required(false)
+                .help("DEPRECATED - Scuba table to route CoreContext to."),
+        )
+        .arg(
+            Arg::with_name(ARG_STATUS_SCUBA_TABLE)
+                .long(ARG_STATUS_SCUBA_TABLE)
+                .takes_value(true)
+                .required(false)
+                .help("Scuba table to route sync outcomes to."),
+        )
+        .arg(
+            Arg::with_name(ARG_MAX_ITERATIONS)
+                .long(ARG_MAX_ITERATIONS)
+                .takes_value(true)
+                .required(false)
+                .help("Max number of iterations to perform."),
+        )
+        .arg(
+            Arg::with_name(ARG_BUFFER_SIZE)
+                .long(ARG_BUFFER_SIZE)
+                .takes_value(true)
+                .required(false)
+                .help("Count of bookmarks to replay concurrently"),
+        )
+        .arg(
+            Arg::with_name(ARG_QUEUE_LIMIT)
+                .long(ARG_QUEUE_LIMIT)
+                .takes_value(true)
+                .required(false)
+                .help("Limit the number of rows to fetch from the queue"),
+        )
+        .arg(
+            Arg::with_name(ARG_DELAY)
+                .long(ARG_DELAY)
+                .takes_value(true)
+                .required(false)
+                .help("How long to sleep after processing a batch"),
+        )
+        .arg(
+            Arg::with_name(ARG_BACKFILL)
+                .long(ARG_BACKFILL)
+                .takes_value(false)
+                .required(false)
+                .help("Whether to look for backfill = 1 entries"),
+        )
+        .arg(
+            Arg::with_name(ARG_SQL_QUEUE_SOURCE)
+                .takes_value(true)
+                .required(true)
+                .possible_values(&[SOURCE_SQLITE, SOURCE_XDB])
+                .help("What engine to use for SQL"),
+        )
+        .arg(
+            Arg::with_name(ARG_SQL_QUEUE_NAME)
+                .takes_value(true)
+                .required(true)
+                .help("Where is the SQL DB (directory for SQLite, XDB tier for XDB)"),
+        );
+
+    let matches = app.get_matches();
+    let readonly_storage = args::parse_readonly_storage(&matches);
+    args::init_cachelib(fb, &matches, None);
+
+    let logger = args::init_logging(fb, &matches);
+    let queue = open_sql(fb, &matches, readonly_storage.0);
+    let (repo_name, RepoConfig { infinitepush, .. }) = args::get_config(fb, &matches)?;
+    let blobrepo = args::open_repo(fb, &logger, &matches);
+
+    let backfill = Backfill(matches.is_present(ARG_BACKFILL));
+    let buffer_size = BufferSize(args::get_usize(
+        &matches,
+        ARG_BUFFER_SIZE,
+        DEFAULT_BUFFER_SIZE,
+    ));
+    let queue_limit = QueueLimit(args::get_usize(
+        &matches,
+        ARG_QUEUE_LIMIT,
+        DEFAULT_QUEUE_LIMIT,
+    ));
+    let maybe_max_iterations = args::get_u64_opt(&matches, ARG_MAX_ITERATIONS);
+    let maybe_delay = args::get_u64_opt(&matches, ARG_DELAY);
+
+    let mut status_scuba = match matches.value_of(ARG_STATUS_SCUBA_TABLE) {
+        Some(table) => ScubaSampleBuilder::new(fb, table),
+        None => ScubaSampleBuilder::with_discard(),
+    };
+
+    status_scuba
+        .add_common_server_data()
+        .add("reponame", repo_name.as_ref());
+
+    let infinitepush_namespace = infinitepush.namespace.ok_or(format_err!(
+        "Infinitepush is not enabled in repository {:?}",
+        repo_name
+    ))?;
+
+    let main = async {
+        let (queue, blobrepo) = future::try_join(queue, blobrepo.compat()).await?;
+
+        let infinitepush_namespace = Arc::new(infinitepush_namespace);
+        let do_replay = {
+            cloned!(logger);
+            move |name: &BookmarkName, hg_cs_id: &HgChangesetId| {
+                sync_bookmark::sync_bookmark(
+                    fb,
+                    blobrepo.clone(),
+                    logger.clone(),
+                    infinitepush_namespace.clone(),
+                    name,
+                    hg_cs_id,
+                )
+            }
+        };
+
+        let stream = replay_stream::process_replay_stream(
+            queue,
+            repo_name,
+            backfill,
+            buffer_size,
+            queue_limit,
+            status_scuba,
+            logger.clone(),
+            do_replay,
+        );
+
+        let mut stream = match maybe_max_iterations {
+            Some(max_iterations) => stream.take(max_iterations).left_stream(),
+            None => stream.right_stream(),
+        }
+        .compat();
+
+        while let Some(_) = stream.next().await {
+            if let Some(delay) = maybe_delay {
+                delay_for(Duration::new(delay, 0)).await;
+            }
+        }
+
+        Ok(())
+    };
+
+    block_execute(
+        main,
+        fb,
+        "commitcloud_bookmarks_filler",
+        &logger,
+        &matches,
+        cmdlib::monitoring::AliveService,
+    )
+}

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/replay_stream.rs
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/replay_stream.rs
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+use anyhow::{format_err, Error, Result};
+use bookmarks::BookmarkName;
+use chrono::Local;
+use cloned::cloned;
+use futures_ext::FutureExt;
+use futures_old::{
+    future::{self, Future, Loop},
+    stream::{self, repeat, Stream},
+};
+use mercurial_types::HgChangesetId;
+use scuba_ext::ScubaSampleBuilder;
+use slog::{info, Logger};
+use stats::prelude::*;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use crate::errors::ErrorKind;
+use crate::sql_replay_bookmarks_queue::{
+    Backfill, BookmarkBatch, Entry, QueueLimit, SqlReplayBookmarksQueue,
+};
+
+define_stats! {
+    prefix = "mononoke.commitcloud_bookmarks_filler.replay_stream";
+    batch_loaded: timeseries(Rate, Sum),
+}
+
+type History<O> = Vec<Result<O, ErrorKind>>;
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub struct BufferSize(pub usize);
+
+fn replay_one_bookmark<F, R, O>(
+    bookmark: BookmarkName,
+    entries: Vec<Entry>,
+    do_replay: R,
+) -> impl Future<Item = (BookmarkName, Result<Vec<Entry>>, History<O>), Error = !>
+where
+    F: Future<Item = O, Error = ErrorKind> + 'static,
+    R: Fn(&BookmarkName, &HgChangesetId) -> F + Sized,
+    O: Sized,
+{
+    // Our loop state is a 3-tuple consisting of:
+    // - The bookmark we are syncing
+    // - The entries left to sync
+    // - The history of outcomes (Results)
+    future::loop_fn(
+        (bookmark, entries, vec![]),
+        move |(bookmark, mut entries, mut history)| match entries.last() {
+            // If we exhausted the entries, then give up.
+            None => {
+                let e = format_err!("No valid changeset to replay for bookmark: {:?}", bookmark);
+                future::err((bookmark, e, history))
+            }
+            .left_future(),
+            // If we still have entries, then try to sync the last element (i.e. the most recent
+            // move). If we succeed, then return this as the replayed entries. If not, then pop the
+            // element we just synced, and try again.
+            Some((_id, hg_cs_id, _timestamp)) => {
+                do_replay(&bookmark, hg_cs_id).then(move |r| {
+                    let ok = r.is_ok();
+                    history.push(r);
+
+                    let next = if ok {
+                        Loop::Break((bookmark, entries, history))
+                    } else {
+                        entries.pop();
+                        Loop::Continue((bookmark, entries, history))
+                    };
+
+                    future::ok(next)
+                })
+            }
+            .right_future(),
+        },
+    )
+    .then(|r| match r {
+        Ok((bookmark, synced, history)) => Ok((bookmark, Ok(synced), history)),
+        Err((bookmark, error, history)) => Ok((bookmark, Err(error), history)),
+    })
+}
+
+pub fn process_replay_stream<F, R, O>(
+    queue: SqlReplayBookmarksQueue,
+    repo_name: String,
+    backfill: Backfill,
+    buffer_size: BufferSize,
+    queue_limit: QueueLimit,
+    status_scuba: ScubaSampleBuilder,
+    logger: Logger,
+    do_replay: R,
+) -> impl Stream<Item = (), Error = Error>
+where
+    F: Future<Item = O, Error = ErrorKind> + 'static,
+    R: Fn(&BookmarkName, &HgChangesetId) -> F + Sized + Clone,
+    O: Sized + Debug,
+{
+    let queue = Arc::new(queue);
+
+    repeat(())
+        .and_then({
+            cloned!(queue);
+            move |_| queue.fetch_batch(&repo_name, backfill, queue_limit)
+        })
+        .and_then({
+            move |batch| {
+                let futs: Vec<_> = batch
+                    .into_iter()
+                    .map(|(bookmark, BookmarkBatch { dt, entries })| {
+                        replay_one_bookmark(bookmark, entries, do_replay.clone())
+                            .map(move |res| (dt, res))
+                    })
+                    .collect();
+
+                STATS::batch_loaded.add_value(futs.len() as i64);
+                info!(logger, "Processing batch: {:?} entries", futs.len());
+
+                stream::iter_ok(futs)
+                    .buffer_unordered(buffer_size.0)
+                    .map({
+                        cloned!(logger, mut status_scuba, queue);
+                        move |(dt, (bookmark, outcome, history))| {
+                            info!(
+                                logger,
+                                "Outcome: bookmark: {:?}: success: {:?}",
+                                bookmark,
+                                outcome.is_ok()
+                            );
+
+                            let latency = Local::now()
+                                .naive_local()
+                                .signed_duration_since(dt)
+                                .num_milliseconds();
+
+                            status_scuba
+                                .add("bookmark", bookmark.into_string())
+                                .add("history", format!("{:?}", history))
+                                .add("success", outcome.is_ok())
+                                .add("sync_latency_ms", latency)
+                                .log();
+
+                            let fut = match outcome {
+                                Ok(entries) => queue.release_entries(&entries).left_future(),
+                                Err(_reason) => future::ok(()).right_future(),
+                            };
+
+                            fut
+                        }
+                    })
+                    .from_err()
+                    .buffer_unordered(buffer_size.0)
+                    .for_each(|_| Ok(()))
+            }
+        })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sql_replay_bookmarks_queue::test_helpers::*;
+
+    use maplit::hashmap;
+    use mercurial_types_mocks::{hash, nodehash};
+    use sql_construct::SqlConstruct;
+    use tokio_compat::runtime::Runtime;
+
+    const BUFFER_SIZE: BufferSize = BufferSize(10);
+    const QUEUE_LIMIT: QueueLimit = QueueLimit(10);
+
+    fn replay_success(
+        _name: &BookmarkName,
+        _cs_id: &HgChangesetId,
+    ) -> impl Future<Item = (), Error = ErrorKind> {
+        future::ok(())
+    }
+
+    fn replay_fail(
+        _name: &BookmarkName,
+        _cs_id: &HgChangesetId,
+    ) -> impl Future<Item = (), Error = ErrorKind> {
+        future::err(ErrorKind::BlobRepoError(Error::msg("err")))
+    }
+
+    fn replay_twos(
+        _name: &BookmarkName,
+        cs_id: &HgChangesetId,
+    ) -> impl Future<Item = (), Error = ErrorKind> {
+        if cs_id == &nodehash::TWOS_CSID {
+            future::ok(())
+        } else {
+            future::err(ErrorKind::BlobRepoError(Error::msg("err")))
+        }
+    }
+
+    fn scuba() -> ScubaSampleBuilder {
+        ScubaSampleBuilder::with_discard()
+    }
+
+    fn logger() -> Logger {
+        Logger::root(slog::Discard, slog::o!())
+    }
+
+    #[test]
+    fn test_sync_success() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let process = process_replay_stream(
+            queue.clone(),
+            repo.clone(),
+            NOT_BACKFILL,
+            BUFFER_SIZE,
+            QUEUE_LIMIT,
+            scuba(),
+            logger(),
+            replay_success,
+        )
+        .take(1)
+        .collect();
+
+        rt.block_on(process)?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+        assert_eq!(real, hashmap! {});
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_fail() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let process = process_replay_stream(
+            queue.clone(),
+            repo.clone(),
+            NOT_BACKFILL,
+            BUFFER_SIZE,
+            QUEUE_LIMIT,
+            scuba(),
+            logger(),
+            replay_fail,
+        )
+        .take(1)
+        .collect();
+
+        rt.block_on(process)?;
+
+        let expected = hashmap! {
+            book1 => batch(t0(), vec![(1 as i64, nodehash::ONES_CSID, t0())]),
+            book2 => batch(t0(), vec![(2 as i64, nodehash::TWOS_CSID, t0())]),
+        };
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_partial() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                3 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::THREES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let process = process_replay_stream(
+            queue.clone(),
+            repo.clone(),
+            NOT_BACKFILL,
+            BUFFER_SIZE,
+            QUEUE_LIMIT,
+            scuba(),
+            logger(),
+            replay_twos,
+        )
+        .take(1)
+        .collect();
+
+        rt.block_on(process)?;
+
+        let expected = hashmap! {
+            book1 => batch(t0(), vec![(3 as i64, nodehash::THREES_CSID, t0())]),
+        };
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+}

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/sql_replay_bookmarks_queue.rs
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/sql_replay_bookmarks_queue.rs
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+use anyhow::Error;
+use ascii::AsciiString;
+use bookmarks::BookmarkName;
+use chrono::naive::NaiveDateTime;
+use futures_old::future::Future;
+use mercurial_types::HgChangesetId;
+use sql::{queries, Connection};
+use sql_construct::SqlConstruct;
+use sql_ext::SqlConnections;
+use std::collections::hash_map::HashMap;
+
+pub type Entry = (i64, HgChangesetId, NaiveDateTime);
+#[derive(Debug, PartialEq, Eq)]
+pub struct BookmarkBatch {
+    pub dt: NaiveDateTime,
+    pub entries: Vec<Entry>,
+}
+pub type Batch = HashMap<BookmarkName, BookmarkBatch>;
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub struct QueueLimit(pub usize);
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub struct Backfill(pub bool);
+
+const DATE_TIME_FORMAT: &'static str = "%Y-%m-%d %H:%M:%S";
+
+queries! {
+    // NOTE: For now, we don't actually limit results here, since we expect fairly low volume on
+    // this, and wouldn't want to have a bad batch of bookmarks at the bottom of the queue block
+    // the rest. If that becomes a problem, we can a) shard on BookmarkName, and b) update this
+    // code to have a limit, as long as we coalesce bookmarks we failed to sync in some way.
+    read FetchQueue(repo_name: String, backfill: i64, limit: usize) -> (i64, BookmarkName, String, String) {
+        "SELECT id, bookmark, node, created_at
+         FROM replaybookmarksqueue
+         WHERE reponame = {repo_name} AND synced = 0 AND backfill = {backfill}
+         ORDER BY id ASC
+         LIMIT {limit}"
+    }
+
+    write ReleaseEntries(>list ids: i64) {
+        none,
+        "UPDATE replaybookmarksqueue SET synced = 1 WHERE id IN {ids}"
+    }
+}
+
+#[derive(Clone)]
+pub struct SqlReplayBookmarksQueue {
+    write_connection: Connection,
+    read_master_connection: Connection,
+}
+
+impl SqlConstruct for SqlReplayBookmarksQueue {
+    const LABEL: &'static str = "replaybookmarksqueue";
+
+    const CREATION_QUERY: &'static str = include_str!("../schemas/sqlite-replaybookmarksqueue.sql");
+
+    fn from_sql_connections(connections: SqlConnections) -> Self {
+        // NOTE: We read from master to avoid reading queue entries we just released.
+        Self {
+            write_connection: connections.write_connection,
+            read_master_connection: connections.read_master_connection,
+        }
+    }
+}
+
+impl SqlReplayBookmarksQueue {
+    pub fn fetch_batch(
+        &self,
+        repo_name: &String,
+        backfill: Backfill,
+        limit: QueueLimit,
+    ) -> impl Future<Item = Batch, Error = Error> {
+        FetchQueue::query(
+            &self.read_master_connection,
+            repo_name,
+            &(if backfill.0 { 1 } else { 0 }),
+            &limit.0,
+        )
+        .and_then(|rows| {
+            let mut r = HashMap::new();
+            for (id, bookmark, hex_cs_id, dt) in rows.into_iter() {
+                let hex_cs_id = AsciiString::from_ascii(hex_cs_id)?;
+                let cs_id = HgChangesetId::from_ascii_str(&hex_cs_id)?;
+
+                // TODO: (torozco) T46163772 queries! macro doesn't support time. MySQL Async does
+                // support it, but we don't have it in SQLite, so I don't think we can expose a
+                // return value for the query that works for both. For now, considering we a) only
+                // use timestamps for logging and b) our local time is the same as the MySQL
+                // server's time (and this all appears to work properly), Naive dates should be OK.
+                let dt = NaiveDateTime::parse_from_str(&dt, DATE_TIME_FORMAT)?;
+
+                r.entry(bookmark)
+                    .or_insert_with(|| BookmarkBatch {
+                        dt: dt.clone(),
+                        entries: vec![],
+                    })
+                    .entries
+                    .push((id, cs_id, dt));
+            }
+            Ok(r)
+        })
+    }
+
+    pub fn release_entries(&self, entries: &[Entry]) -> impl Future<Item = (), Error = Error> {
+        let ids: Vec<_> = entries.iter().map(|e| e.0).collect();
+        ReleaseEntries::query(&self.write_connection, &ids[..]).map(|_| ())
+    }
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+    use super::*;
+
+    use anyhow::Result;
+    use mercurial_types::hash::Sha1;
+    use tokio_compat::runtime::Runtime;
+
+    pub const BACKFILL: Backfill = Backfill(true);
+    pub const NOT_BACKFILL: Backfill = Backfill(false);
+
+    pub fn t0() -> NaiveDateTime {
+        NaiveDateTime::from_timestamp(10, 0)
+    }
+
+    pub fn t1() -> NaiveDateTime {
+        NaiveDateTime::from_timestamp(10, 0)
+    }
+
+    pub fn batch(dt: NaiveDateTime, entries: Vec<Entry>) -> BookmarkBatch {
+        BookmarkBatch { dt, entries }
+    }
+
+    queries! {
+        write InsertEntries(
+            values: (id: i64, repo_name: String, bookmark: String, node: String, bookmark_hash: String, created_at: String, backfill: i64)
+        ) {
+            none,
+            "INSERT INTO replaybookmarksqueue (id, reponame, bookmark, node, bookmark_hash, created_at, backfill) VALUES {values}"
+        }
+    }
+
+    pub fn insert_entries(
+        rt: &mut Runtime,
+        queue: &SqlReplayBookmarksQueue,
+        entries: &Vec<(i64, String, BookmarkName, Sha1, NaiveDateTime, Backfill)>,
+    ) -> Result<()> {
+        let rows: Vec<_> = entries
+            .iter()
+            .map(|(id, repo, bookmark, cs_id, t, backfill)| {
+                (
+                    id,
+                    repo,
+                    bookmark.to_string(),
+                    cs_id.to_string(),
+                    t.format(DATE_TIME_FORMAT).to_string(),
+                    (if backfill.0 { 1 } else { 0 }) as i64,
+                )
+            })
+            .collect();
+
+        // NOTE: we don't actually compute the bookmark_hash here because we don't use that yet.
+        let refs: Vec<_> = rows
+            .iter()
+            .map(|(id, repo, bookmark, cs_id, t, b)| (*id, *repo, bookmark, cs_id, bookmark, t, b))
+            .collect();
+
+        rt.block_on(InsertEntries::query(&queue.write_connection, &refs[..]))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use test_helpers::*;
+
+    use anyhow::Result;
+    use maplit::hashmap;
+    use mercurial_types_mocks::{hash, nodehash};
+    use tokio_compat::runtime::Runtime;
+
+    const QUEUE_LIMIT: QueueLimit = QueueLimit(10);
+
+    #[test]
+    fn test_fetch_basic_batch() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+
+        let expected = hashmap! {
+            book1 => batch(t0(), vec![(1 as i64, nodehash::ONES_CSID, t0())]),
+            book2 => batch(t0(), vec![(2 as i64, nodehash::TWOS_CSID, t0())]),
+        };
+
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fetch_coalesced_batch() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                3 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::THREES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                4 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::FOURS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                5 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::FIVES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+
+        let book1_entries = vec![
+            (1 as i64, nodehash::ONES_CSID, t0()),
+            (3 as i64, nodehash::THREES_CSID, t0()),
+            (4 as i64, nodehash::FOURS_CSID, t0()),
+            (5 as i64, nodehash::FIVES_CSID, t0()),
+        ];
+
+        let expected = hashmap! {
+            book1 => batch(t0(), book1_entries),
+            book2 => batch(t0(), vec![(2 as i64, nodehash::TWOS_CSID, t0())]),
+        };
+
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_batch() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                3 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::THREES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                4 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::FOURS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let release = vec![
+            (1 as i64, nodehash::ONES_CSID, t0()),
+            (2 as i64, nodehash::TWOS_CSID, t0()),
+        ];
+
+        rt.block_on(queue.release_entries(&release))?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+
+        let expected = hashmap! {
+            book1 => batch(t0(), vec![(3 as i64, nodehash::THREES_CSID, t0())]),
+            book2 => batch(t0(), vec![(4 as i64, nodehash::FOURS_CSID, t0())]),
+        };
+
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repo_filtering() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo1 = "repo1".to_string();
+        let repo2 = "repo2".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo1.to_string(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo2.to_string(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo1, NOT_BACKFILL, QUEUE_LIMIT))?;
+
+        let expected = hashmap! {
+            book1 => batch(t0(), vec![(1 as i64, nodehash::ONES_CSID, t0())]),
+        };
+
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_age() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.to_string(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.to_string(),
+                book1.clone(),
+                hash::TWOS,
+                t1(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+
+        let entries = vec![
+            (1 as i64, nodehash::ONES_CSID, t0()),
+            (2 as i64, nodehash::TWOS_CSID, t1()),
+        ];
+
+        let expected = hashmap! { book1 => batch(t0(), entries) };
+
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_limit() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+        let book2 = BookmarkName::new("book2")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::TWOS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                3 as i64,
+                repo.clone(),
+                book1.clone(),
+                hash::THREES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                4 as i64,
+                repo.clone(),
+                book2.clone(),
+                hash::FOURS,
+                t0(),
+                NOT_BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let real = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QueueLimit(2)))?;
+
+        let expected = hashmap! {
+            book1 => batch(t0(), vec![(1 as i64, nodehash::ONES_CSID, t0())]),
+            book2 => batch(t0(), vec![(2 as i64, nodehash::TWOS_CSID, t0())]),
+        };
+
+        assert_eq!(real, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_backfill() -> Result<()> {
+        let mut rt = Runtime::new()?;
+        let queue = SqlReplayBookmarksQueue::with_sqlite_in_memory()?;
+
+        let repo = "repo1".to_string();
+        let book1 = BookmarkName::new("book1")?;
+
+        let entries = vec![
+            (
+                1 as i64,
+                repo.to_string(),
+                book1.clone(),
+                hash::ONES,
+                t0(),
+                NOT_BACKFILL,
+            ),
+            (
+                2 as i64,
+                repo.to_string(),
+                book1.clone(),
+                hash::TWOS,
+                t0(),
+                BACKFILL,
+            ),
+        ];
+        insert_entries(&mut rt, &queue, &entries)?;
+
+        let real_backfill = rt.block_on(queue.fetch_batch(&repo, BACKFILL, QUEUE_LIMIT))?;
+        let real_not_backfill = rt.block_on(queue.fetch_batch(&repo, NOT_BACKFILL, QUEUE_LIMIT))?;
+
+        let expected_backfill = hashmap! {
+            book1.clone() => batch(t0(), vec![(2 as i64, nodehash::TWOS_CSID, t0())])
+        };
+
+        let expected_not_backfill = hashmap! {
+            book1.clone() => batch(t0(), vec![(1 as i64, nodehash::ONES_CSID, t0())])
+        };
+
+        assert_eq!(real_backfill, expected_backfill);
+        assert_eq!(real_not_backfill, expected_not_backfill);
+
+        Ok(())
+    }
+}

--- a/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/sync_bookmark.rs
+++ b/eden/mononoke/mononoke_commitcloud_bookmarks_filler/src/sync_bookmark.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+use blobrepo::BlobRepo;
+use blobrepo_hg::BlobRepoHg;
+use bookmarks::BookmarkName;
+use cloned::cloned;
+use context::CoreContext;
+use fbinit::FacebookInit;
+use futures::future::TryFutureExt;
+use futures_ext::FutureExt;
+use futures_old::future::{self, Future};
+use mercurial_types::HgChangesetId;
+use metaconfig_types::InfinitepushNamespace;
+use slog::{info, Logger};
+use stats::prelude::*;
+use std::sync::Arc;
+
+use crate::errors::ErrorKind;
+
+define_stats! {
+    prefix = "mononoke.commitcloud_bookmarks_filler.sync_bookmark";
+    update: timeseries(Rate, Sum),
+    create: timeseries(Rate, Sum),
+    success: timeseries(Rate, Sum),
+    failure: timeseries(Rate, Sum),
+    total: timeseries(Rate, Sum),
+}
+
+pub fn sync_bookmark(
+    fb: FacebookInit,
+    blobrepo: BlobRepo,
+    logger: Logger,
+    infinitepush_namespace: Arc<InfinitepushNamespace>,
+    name: &BookmarkName,
+    hg_cs_id: &HgChangesetId,
+) -> impl Future<Item = (), Error = ErrorKind> {
+    if !infinitepush_namespace.matches_bookmark(name) {
+        return future::err(ErrorKind::InvalidBookmarkForNamespace(name.clone())).left_future();
+    }
+
+    cloned!(name, hg_cs_id);
+
+    let ctx = CoreContext::new_with_logger(fb, logger.clone());
+
+    let maybe_new_cs_id = blobrepo.get_bonsai_from_hg(ctx.clone(), hg_cs_id);
+    let maybe_old_cs_id = blobrepo.get_bonsai_bookmark(ctx.clone(), &name);
+
+    maybe_old_cs_id
+        .join(maybe_new_cs_id)
+        .map_err(ErrorKind::BlobRepoError)
+        .and_then(move |(maybe_old_cs_id, maybe_new_cs_id)| {
+            match maybe_new_cs_id {
+                Some(new_cs_id) => Ok((maybe_old_cs_id, new_cs_id)),
+                None => Err(ErrorKind::HgChangesetDoesNotExist(hg_cs_id)),
+            }
+        })
+        .and_then({
+            cloned!(blobrepo, ctx, logger);
+            move |(maybe_old_cs_id, new_cs_id)| {
+                info!(
+                    logger,
+                    "Updating bookmark {:?}: {:?} -> {:?}", name, maybe_old_cs_id, new_cs_id
+                );
+
+                let mut txn = blobrepo.update_bookmark_transaction(ctx);
+
+                let res = match maybe_old_cs_id {
+                    Some(old_cs_id) => {
+                        STATS::update.add_value(1);
+                        txn.update_scratch(&name, new_cs_id, old_cs_id)
+                    }
+                    None => {
+                        STATS::create.add_value(1);
+                        txn.create_scratch(&name, new_cs_id)
+                    }
+                };
+
+                res.map(|_| txn).map_err(ErrorKind::BlobRepoError)
+            }
+        })
+        .and_then(|txn| txn.commit().compat().map_err(ErrorKind::BlobRepoError))
+        .and_then(|success| {
+            if success {
+                future::ok(())
+            } else {
+                future::err(ErrorKind::BookmarkTransactionFailed)
+            }
+        })
+        .inspect_result(|res| {
+            STATS::total.add_value(1);
+
+            if res.is_ok() {
+                STATS::success.add_value(1);
+            } else {
+                STATS::failure.add_value(1);
+            }
+        })
+        .right_future()
+}

--- a/eden/mononoke/server/context/src/oss.rs
+++ b/eden/mononoke/server/context/src/oss.rs
@@ -7,15 +7,15 @@
 
 use anyhow::Error;
 use futures::{future::ok, Future};
-use sshrelay::SshEnvVars;
+use sshrelay::Metadata;
 
 use crate::core::CoreContext;
 
-pub fn is_quicksand(_ssh_env_vars: &SshEnvVars) -> bool {
+pub fn is_quicksand(_metadata: &Metadata) -> bool {
     false
 }
 
-pub fn is_external_sync(_ssh_env_vars: &SshEnvVars) -> bool {
+pub fn is_external_sync(_metadata: &Metadata) -> bool {
     false
 }
 

--- a/eden/mononoke/server/repo_listener/src/connection_acceptor.rs
+++ b/eden/mononoke/server/repo_listener/src/connection_acceptor.rs
@@ -294,18 +294,6 @@ async fn try_convert_preamble_to_metadata(
         None => addr,
     };
 
-    // SSH Connections are either authentication via ssh certificate principals or
-    // via some form of keyboard-interactive. In the case of certificates we should always
-    // rely on these. If they are not present, we should fallback to use the unix username
-    // as the primary principal.
-    let ssh_identities = match vars.ssh_cert_principals {
-        Some(ssh_identities) => ssh_identities,
-        None => preamble
-            .unix_name()
-            .ok_or_else(|| anyhow!("missing username and principals from preamble"))?
-            .to_string(),
-    };
-
     let priority = match Priority::extract_from_preamble(&preamble) {
         Ok(Some(p)) => {
             info!(&conn_log, "Using priority: {}", p; "remote" => "true");
@@ -318,9 +306,39 @@ async fn try_convert_preamble_to_metadata(
         }
     };
 
+    let identity = {
+        #[cfg(fbcode_build)]
+        {
+            // SSH Connections are either authentication via ssh certificate principals or
+            // via some form of keyboard-interactive. In the case of certificates we should always
+            // rely on these. If they are not present, we should fallback to use the unix username
+            // as the primary principal.
+            let ssh_identities = match vars.ssh_cert_principals {
+                Some(ssh_identities) => ssh_identities,
+                None => preamble
+                    .unix_name()
+                    .ok_or_else(|| anyhow!("missing username and principals from preamble"))?
+                    .to_string(),
+            };
+
+            MononokeIdentity::try_from_ssh_encoded(&ssh_identities)?
+        }
+        #[cfg(not(fbcode_build))]
+        {
+            use maplit::btreeset;
+            btreeset! { MononokeIdentity::new(
+                "USER",
+               preamble
+                    .unix_name()
+                    .ok_or_else(|| anyhow!("missing username from preamble"))?
+                    .to_string(),
+            )?}
+        }
+    };
+
     Ok(Metadata::new(
         preamble.misc.get("session_uuid"),
-        MononokeIdentity::try_from_ssh_encoded(&ssh_identities)?,
+        identity,
         priority,
         preamble
             .misc

--- a/eden/mononoke/tests/integration/integration_runner_real.py
+++ b/eden/mononoke/tests/integration/integration_runner_real.py
@@ -44,7 +44,7 @@ DISABLE_ALL_NETWORK_ACCESS_SKIPLIST: Set[str] = {
     "test-commitcloud-forwardfiller.t",
     "test-commitcloud-reversefiller.t",
     # Purposely not disabling network as this tests reverse dns lookups
-    "test-metadata.t",
+    "test-metadata-fb-host.t",
 }
 
 PY3_SKIPLIST: Set[str] = set()

--- a/eden/mononoke/tests/integration/manifest_deps
+++ b/eden/mononoke/tests/integration/manifest_deps
@@ -17,6 +17,7 @@ MONONOKE_BINS = {
     "MONONOKE_BLOBIMPORT": "blobimport",
     "MONONOKE_BLOBSTORE_HEALER": "blobstore_healer",
     "MONONOKE_BONSAI_VERIFY": "bonsai_verify",
+    "MONONOKE_BOOKMARKS_FILLER": "mononoke_commitcloud_bookmarks_filler",
     "MONONOKE_FASTREPLAY": "fastreplay",
     "MONONOKE_GITIMPORT": "gitimport",
     "MONONOKE_HGCLI": "hgcli",

--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -169,7 +169,9 @@ def get_test_groups(repo_root):
 def get_tests_to_run(repo_root, tests, groups_to_run, rerun_failed):
     test_groups = get_test_groups(repo_root)
 
-    groups_to_run = set(groups_to_run or ([TestGroup.PASSING] if not tests else []))
+    groups_to_run = set(
+        groups_to_run or ([TestGroup.PASSING] if not (tests or rerun_failed) else [])
+    )
 
     tests_to_run = set()
     for group in groups_to_run:

--- a/eden/mononoke/tests/integration/run_tests_getdeps.py
+++ b/eden/mononoke/tests/integration/run_tests_getdeps.py
@@ -112,11 +112,14 @@ def get_test_groups(repo_root):
             "test-push-protocol-lfs.t",
             "test-remotefilelog-lfs.t",
         },
-        TestGroup.FLAKY: {"test-walker-count-objects.t", "test-walker-error-as-data.t"},
+        TestGroup.FLAKY: {
+            "test-cache-warmup-microwave.t",
+            "test-gitimport-octopus.t",
+            "test-redaction.t",
+            "test-walker-count-objects.t",
+            "test-walker-error-as-data.t",
+        },
         TestGroup.BROKEN: {
-            "test-backsync-forever.t",  # Unknown issue
-            "test-bookmarks-filler.t",  # Probably missing binary
-            "test-cmd-manual-scrub.t",  # Just wrong output
             "test-edenapi-server-commit-location-to-hash.t",  # Missing eden/scm's commands
             "test-edenapi-server-commit-revlog-data.t",  # Missing eden/scm's commands
             "test-edenapi-server-complete-trees.t",  # Missing eden/scm's commands
@@ -124,10 +127,8 @@ def get_test_groups(repo_root):
             "test-edenapi-server-history.t",  # Missing eden/scm's commands
             "test-edenapi-server-trees.t",  # Missing eden/scm's commands
             "test-fastreplay-inline-args.t",  # Returns different data in OSS
-            "test-gitimport-octopus.t",  # Unknown, fails on GitHub MacOs
             "test-gitimport.t",  # Issue with hggit extension
             "test-hook-tailer.t",  # Issue with hggit extension
-            "test-redaction.t",  # This test is temporary broken
             "test-remotefilelog-lfs-client-certs.t",  # Returns different data in OSS
             "test-server.t",  # Returns different data in OSS
             "test-unbundle-replay-hg-recording.t",  # Returns different data in OSS

--- a/eden/mononoke/tests/integration/test-metadata.t
+++ b/eden/mononoke/tests/integration/test-metadata.t
@@ -57,29 +57,4 @@ pull from mononoke and log data
   remote: }
   searching for changes
   no changes found
-  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true LOCALIP="2401:db00:31ff:ff1f:face:b00c:0:598" hgmn pull
-  pulling from ssh://user@dummy/repo
-  remote: Metadata {
-  remote:     session_id: SessionId(
-  remote:         "*", (glob)
-  remote:     ),
-  remote:     identities: {
-  remote:         MononokeIdentity {
-  remote:             id_type: "USER",
-  remote:             id_data: "foobar",
-  remote:         },
-  remote:     },
-  remote:     priority: Default,
-  remote:     client_debug: true,
-  remote:     client_ip: Some(
-  remote:         V6(
-  remote:             2401:db00:31ff:ff1f:face:b00c:0:598,
-  remote:         ),
-  remote:     ),
-  remote:     client_hostname: Some(
-  remote:         "hg-regional6-shv-01.rcln0.facebook.com",
-  remote:     ),
-  remote: }
-  searching for changes
-  no changes found
 


### PR DESCRIPTION
Summary: This makes the test-bookmarks-filler.t pass. Additionally remove few tests from exclusion lists as they started to pass.

Differential Revision: D23757401

