### PR TITLE
mononoke/integration tests: use $LOCALIP instead of ::1 or 127.0.0.1

### DIFF
--- a/eden/mononoke/tests/integration/nossh.sh
+++ b/eden/mononoke/tests/integration/nossh.sh
@@ -9,7 +9,12 @@ REPONAME="${REPONAME:-"$(hg config | grep remotefilelog.reponame | cut -d "=" -f
 CA_PEM=${CA_PEM:-"${TEST_CERTS}/root-ca.crt"}
 PRIVATE_KEY=${PRIVATE_KEY:-"${TEST_CERTS}/localhost.key"}
 CERT=${CERT:-"${TEST_CERTS}/localhost.crt"}
-MONONOKE_PATH="[::]:${MONONOKE_SOCKET}"
+if [[ $LOCALIP == *":"* ]]; then
+  # it is ipv6, surround with brackets
+  MONONOKE_PATH="[$LOCALIP]:${MONONOKE_SOCKET}"
+else
+  MONONOKE_PATH="$LOCALIP:${MONONOKE_SOCKET}"
+fi
 COMMON_NAME="localhost"
 
 "$MONONOKE_HGCLI" -R "$REPONAME" serve --stdio --mononoke-path "$MONONOKE_PATH" \

--- a/eden/mononoke/tests/integration/test-lfs-server-proxy-skip-upstream.t
+++ b/eden/mononoke/tests/integration/test-lfs-server-proxy-skip-upstream.t
@@ -12,8 +12,8 @@
 
 # Start a "server" that never responds as the upstream
   $ upstream_port="$(get_free_socket)"
-  $ upstream="http://127.0.0.1:${upstream_port}/"
-  $ ncat --sh-exec "sleep 1" --keep-open --listen 127.0.0.1 "$upstream_port" &
+  $ upstream="http://${LOCALIP}:${upstream_port}/"
+  $ ncat --sh-exec "sleep 1" --keep-open --listen "$LOCALIP" "$upstream_port" &
   $ nc_pid="$!"
 
 # Start a LFS server

--- a/eden/mononoke/tests/integration/test-metadata-no-network.t
+++ b/eden/mononoke/tests/integration/test-metadata-no-network.t
@@ -32,7 +32,7 @@ start mononoke
   $ wait_for_mononoke
 
 pull from mononoke and log data
-  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true LOCALIP="127.0.0.1" hgmn pull
+  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true SSH_IP_OVERRIDE="$LOCALIP" hgmn pull
   pulling from ssh://user@dummy/repo
   remote: Metadata {
   remote:     session_id: SessionId(
@@ -58,7 +58,7 @@ pull from mononoke and log data
   remote: }
   searching for changes
   no changes found
-  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true LOCALIP="2401:db00:31ff:ff1f:face:b00c:0:598" hgmn pull
+  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true SSH_IP_OVERRIDE="2401:db00:31ff:ff1f:face:b00c:0:598" hgmn pull
   pulling from ssh://user@dummy/repo
   remote: Metadata {
   remote:     session_id: SessionId(

--- a/eden/mononoke/tests/integration/test-metadata.t
+++ b/eden/mononoke/tests/integration/test-metadata.t
@@ -32,7 +32,7 @@ start mononoke
   $ wait_for_mononoke
 
 pull from mononoke and log data
-  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true LOCALIP="127.0.0.1" hgmn pull
+  $ MOCK_USERNAME=foobar CLIENT_DEBUG=true SSH_IP_OVERRIDE="$LOCALIP" hgmn pull
   pulling from ssh://user@dummy/repo
   remote: Metadata {
   remote:     session_id: SessionId(

--- a/eden/scm/tests/dummyssh
+++ b/eden/scm/tests/dummyssh
@@ -49,7 +49,9 @@ while host_index < len(sys.argv) and sys.argv[host_index].startswith("-"):
 if sys.argv[host_index] != "user@dummy":
     sys.exit(-1)
 
-os.environ["SSH_CLIENT"] = "%s 1 2" % os.environ.get("LOCALIP", "127.0.0.1")
+os.environ["SSH_CLIENT"] = "%s 1 2" % os.environ.get(
+    "SSH_IP_OVERRIDE", os.environ.get("LOCALIP", "127.0.0.1")
+)
 
 log = open("dummylog", "ab")
 log.write(b"Got arguments")
@@ -77,9 +79,13 @@ if "hgcli" in hgcmd:
     cert = os.path.join(certdir, "localhost.crt")
     capem = os.path.join(certdir, "root-ca.crt")
     privatekey = os.path.join(certdir, "localhost.key")
+    localip = os.environ.get("LOCALIP", "127.0.0.1")
+    if ":" in localip:
+        # this is ipv6, put it in brackets
+        localip = "[" + localip + "]"
 
     hgcmd += (
-        " --mononoke-path [::1]:"
+        (" --mononoke-path %s:" % localip)
         + os.getenv("MONONOKE_SOCKET")
         + (
             " --cert %s --ca-pem %s --private-key %s --common-name localhost"

--- a/eden/scm/tests/dummyssh3.py
+++ b/eden/scm/tests/dummyssh3.py
@@ -56,7 +56,9 @@ while host_index < len(sys.argv) and sys.argv[host_index].startswith("-"):
 if sys.argv[host_index] != "user@dummy":
     sys.exit(-1)
 
-os.environ["SSH_CLIENT"] = "%s 1 2" % os.environ.get("LOCALIP", "127.0.0.1")
+os.environ["SSH_CLIENT"] = "%s 1 2" % os.environ.get(
+    "SSH_IP_OVERRIDE", os.environ.get("LOCALIP", "127.0.0.1")
+)
 
 log = open("dummylog", "ab")
 log.write(b"Got arguments")
@@ -85,9 +87,13 @@ if "hgcli" in hgcmd:
     cert = os.path.join(certdir, "localhost.crt")
     capem = os.path.join(certdir, "root-ca.crt")
     privatekey = os.path.join(certdir, "localhost.key")
+    localip = os.environ.get("LOCALIP", "127.0.0.1")
+    if ":" in localip:
+        # this is ipv6, put it in brackets
+        localip = "[" + localip + "]"
 
     hgcmd += (
-        " --mononoke-path [::1]:"
+        (" --mononoke-path %s:" % localip)
         + none_throws(os.getenv("MONONOKE_SOCKET"))
         + (
             " --cert %s --ca-pem %s --private-key %s --common-name localhost"


### PR DESCRIPTION
Summary:
Using $LOCALIP will ensure more consistent behavior when setting up the server in ipv4 or ipv6.
The LOCALIP variable was also abused when it was used to override ssh client address, so SSH_IP_OVEERIDE env was created here.
Lastly the result of `curl` call is now printed whenever the test failed to verify that Mononoke is running.

Differential Revision: D24108186

