### PR TITLE
rust/oss: update rustc version to 1.47 in rust-shed and eden GitHub workflows

### DIFF
--- a/.github/workflows/eden_scm_lib_edenapi_tools_linux.yml
+++ b/.github/workflows/eden_scm_lib_edenapi_tools_linux.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install system deps

--- a/.github/workflows/eden_scm_lib_edenapi_tools_mac.yml
+++ b/.github/workflows/eden_scm_lib_edenapi_tools_mac.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install system deps

--- a/.github/workflows/edenscm_linux.yml
+++ b/.github/workflows/edenscm_linux.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install Python 2.7

--- a/.github/workflows/edenscm_mac.yml
+++ b/.github/workflows/edenscm_mac.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install Python 2.7

--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install Python 2.7

--- a/.github/workflows/mononoke-integration_mac.yml
+++ b/.github/workflows/mononoke-integration_mac.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install Python 2.7

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install system deps

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install system deps


### PR DESCRIPTION
Summary: Internal codebase was updated to 1.47 with code changes that are no longer compatible with 1.44. Updating to OSS 1.47 to fix build.

Reviewed By: ikostia, mzr

Differential Revision: D24389087

