### PR TITLE
change logging.warn to logging.warning

### DIFF
--- a/eden/integration/hg/lib/hg_extension_test_base.py
+++ b/eden/integration/hg/lib/hg_extension_test_base.py
@@ -437,7 +437,7 @@ class JournalEntry(object):
         # Search for the last argument that gets added by the profiling code.
         m = re.search("--config 'profiling.freq=[0-9]+' ", command)
         if not m:
-            logging.warn(
+            logging.warning(
                 "did not find match when trying to strip profiling "
                 f"arguments: {command}"
             )


### PR DESCRIPTION
Summary: logging.warn() is deprecated since Python 3.3 in favor of logging.warning()

Reviewed By: ahornby

Differential Revision: D25870738

