### PR TITLE
HTE lint-ignore message cleanup at fbcode

### DIFF
--- a/eden/scm/lib/backingstore/c_api/HgNativeBackingStore.cpp
+++ b/eden/scm/lib/backingstore/c_api/HgNativeBackingStore.cpp
@@ -52,7 +52,7 @@ void getBlobBatchCallback(
       size,
       local,
       // We need to take address of the function, not to forward it.
-      // @lint-ignore HOWTOEVEN CLANGTIDY
+      // @lint-ignore CLANGTIDY
       &fn,
       [](void* fn, size_t index, RustCFallibleBase result) {
         (*static_cast<Fn*>(fn))(index, result);


### PR DESCRIPTION
Summary: The diff removes HOWTOEVEN from all lint-ignore messages at fbcode

Reviewed By: dkgi

Differential Revision: D26278830

