### PR TITLE
Update dashmap version. (#3355)

### DIFF
--- a/eden/mononoke/walker/Cargo.toml
+++ b/eden/mononoke/walker/Cargo.toml
@@ -56,7 +56,7 @@ auto_impl = "0.4"
 bitflags = "1.2"
 bytes = { version = "0.5", features = ["serde"] }
 clap = "2.33"
-dashmap = {version = "3.11.10", features = ["serde"] }
+dashmap = {version = "4.0.2", features = ["serde"] }
 derive_more = "0.99.3"
 filetime = "0.2.9"
 futures = { version = "0.3.5", features = ["async-await", "compat"] }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/relay/pull/3355

Followed [this guide](https://www.internalfb.com/intern/wiki/Rust-at-facebook/Managing_fbsource_third-party_with_Reindeer/) to update the dependecies.

For more context on serde error fixed by this update, check this https://github.com/xacrimon/dashmap/issues/133

Differential Revision: D26423198

