### PR TITLE
Use released cursive_tab and cursive_buffered_backend version

### DIFF
--- a/eden/mononoke/Cargo.toml
+++ b/eden/mononoke/Cargo.toml
@@ -213,7 +213,6 @@ addr2line = { git = "https://github.com/gimli-rs/addr2line.git", rev = "0b6b6018
 bytecount = { git = "https://github.com/llogiq/bytecount", rev = "469eaf8395c99397cd64d059737a9054aa014088" }
 chashmap = { git = "https://gitlab.redox-os.org/ahornby/chashmap", rev = "901ace2ca3cdbc2095adb1af111d211e254e2aae" }
 const-random = { git = "https://github.com/fbsource/const-random", rev = "374c5b46427fe2ffbf6acbd9c1687e0f1a809f95" }
-cursive_buffered_backend = { git = "https://github.com/chengxiong-ruan/cursive_buffered_backend", branch = "upgrade_cursive_core_from_v0.4.1" }
 enumset = { git = "https://github.com/danobi/enumset", rev = "4c01c583c27a725948fededbfb3461c572a669a4" }
 gotham = { git = "https://github.com/krallin/gotham.git", rev = "6c1612c7189893f31c6c3fa2dda11c0b6d83e1ac" }
 gotham-02 = { package = "gotham", git = "https://github.com/krallin/gotham-02.git", rev = "1eb3b976c31e7e4334b188f3abfa5cc2e5cae033" }


### PR DESCRIPTION
Summary: Use released version to fix cursive_core version conflicts.

Differential Revision: D27032206

