### PR TITLE
Remove rsocket-cpp github_hashes file

### DIFF
--- a/build/deps/github_hashes/rsocket/rsocket-cpp-rev.txt
+++ b/build/deps/github_hashes/rsocket/rsocket-cpp-rev.txt
@@ -1,1 +1,0 @@
-Subproject commit 45ed594ebd6701f40795c31ec922d784ec7fc921


### PR DESCRIPTION
Summary:
eden depended on the rsocket-cpp repository via fbthrift, but fbthrift
removed its rsocket-cpp dependency last year.  Remove the github_hashes
file for this repository since it is no longer necessary.