### PR TITLE
Show commit being rebased during unfinished rebase

### DIFF
--- a/eden/scm/edenscm/hgext/morestatus.py
+++ b/eden/scm/edenscm/hgext/morestatus.py
@@ -12,6 +12,7 @@ the state of the repo
 import math
 import os
 
+from edenscm.hgext.rebase import rebaseruntime
 from edenscm.mercurial import (
     commands,
     hbisect,
@@ -82,6 +83,18 @@ def helpmessage(ui, continuecmd, abortcmd):
 
 def rebasemsg(repo, ui):
     helpmessage(ui, "hg rebase --continue", "hg rebase --abort")
+
+    rbsrt = rebaseruntime(repo, ui, None, {})
+    rbsrt.restorestatus()
+    for (src, dest) in rbsrt.destmap.items():
+        if dest == rbsrt.originalwd:
+            ui.warn(
+                prefixlines(
+                    f"\nCurrently rebasing {repo[src]}: {repo[src].shortdescription()}"
+                )
+            )
+            break
+
 
 
 def histeditmsg(repo, ui):

--- a/eden/scm/tests/test-fb-hgext-morestatus.t
+++ b/eden/scm/tests/test-fb-hgext-morestatus.t
@@ -143,6 +143,8 @@ Test rebase state
   # To mark files as resolved:  hg resolve --mark FILE
   # To continue:                hg rebase --continue
   # To abort:                   hg rebase --abort
+  # 
+  # Currently rebasing 2977a57ce863: remove content
 
 Test status in rebase state with resolved files
   $ hg resolve --mark a
@@ -156,6 +158,8 @@ Test status in rebase state with resolved files
   # No unresolved merge conflicts.
   # To continue:                hg rebase --continue
   # To abort:                   hg rebase --abort
+  # 
+  # Currently rebasing 2977a57ce863: remove content
 
 Test hg status is normal after rebase abort
   $ hg rebase --abort -q
@@ -173,6 +177,8 @@ Test rebase with an interrupted update:
   # The repository is in an unfinished *rebase* state.
   # To continue:                hg rebase --continue
   # To abort:                   hg rebase --abort
+  # 
+  # Currently rebasing 2977a57ce863: remove content
   $ hg rebase --abort -q
   rebase aborted
 


### PR DESCRIPTION
Summary:
Adds
```
# Currently rebasing {hash}: {message}
```

during an unfinished rebase state.

Differential Revision: D31743065

